### PR TITLE
changed random line command to use shuf (hopefully improving randomness)

### DIFF
--- a/bin/rand.fish
+++ b/bin/rand.fish
@@ -24,7 +24,7 @@ end
 
 set file (chan_file $chan $rest)
 if test -n "$file" -a -f $file
-    set line (cat $file | sort -R | head -1)
+    set line (shuf -n 1 $file)
     if test -n "$should_rainbow"
         msg $chan (rainbow $line)
     else


### PR DESCRIPTION
i've been noticing some suspicious behavior in fish's random line functionality, where it'll seemingly prefer certain lines. according to gpt this can be caused by locale and shuf shouldn't have this problem.

From gpt:

The command `sort -R` is meant to randomize the order of lines in a file. However, the method `sort` uses to randomize the lines can be affected by the locale settings. If your locale is set to `C`, `sort -R` should be using true random shuffling. However, if your locale is set to something else (like `en_US.UTF-8`), `sort -R` can exhibit biased behavior, which might explain why certain lines are favored.

To check your current locale setting, you can run:

```bash
echo $LC_ALL $LC_COLLATE $LANG
```

If you want to ensure that `sort -R` is using true random shuffling, you can explicitly set the `LC_ALL` locale to `C` for the duration of the command:

```bash
cat $file | LC_ALL=C sort -R | head -1
```

This command sets the locale to `C` only for the duration of the `sort` command, ensuring that you get a truly randomized order.

However, if you are looking to pick a random line frequently, there are more efficient methods than sorting the entire file and then picking the first line. Here's one way using `shuf`:

```bash
shuf -n 1 $file
```

`shuf` is specifically designed for this purpose and should be faster and more efficient than the `sort -R` method for large files.